### PR TITLE
Bump release with migrations fix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,2 +1,6 @@
 # Change Log
 All notable changes to this project will be documented in this file.
+
+## [0.1.1]
+### Fixed
+- fixed migrations

--- a/fdadb/__init__.py
+++ b/fdadb/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __title__ = "FDA Drug Database"
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __author__ = "Michal Proszek"
 __license__ = "MIT"
 __copyright__ = "Copyright 2018 Roman Health"


### PR DESCRIPTION
This updates the release tags in this repo in preparation for a 0.1.1 release.

I plan on tagging a github release once this merges for 0.1.1 and also pushing a new pypi package as well.